### PR TITLE
Add documentation on tag types in `EasyTokenTagger` tutorial

### DIFF
--- a/adaptnlp/sequence_classification.py
+++ b/adaptnlp/sequence_classification.py
@@ -32,7 +32,7 @@ class EasySequenceClassifier:
         * **text** - Text input, it can be a string or any of Flair's `Sentence` input formats
         * **model_name_or_path** - The hosted model name key or model path
         * **mini_batch_size** - The mini batch size for running inference
-        * **&ast;*ast;kwargs** - (Optional) Keyword Arguments for Flair's `TextClassifier.predict()` method params
+        * **&ast;&ast;kwargs** - (Optional) Keyword Arguments for Flair's `TextClassifier.predict()` method params
         **return** A list of Flair's `Sentence`'s
         """
         # Load Text Classifier Model and Pytorch Module into tagger dict

--- a/docs/tutorial/token-tagging.md
+++ b/docs/tutorial/token-tagging.md
@@ -109,6 +109,15 @@ for sen in sentences:
         print(entity)
 ```
 
+Here are some additional tag_types that support some of Flair's pre-trained token taggers:
+##### German Models
+| tag_type | Description |
+| -------------    | ------------- |
+| 'ner' | For Named Entity Recognition tagged text |
+| 'pos' | For Parts of Speech tagged text |
+| 'np' | For Syntactic Chunking tagged text |
+
+NOTE: You can add your own tag_types when running the sequence classifier trainer in AdaptNLP.
 
 ### Tagging with `tag_all(text: str, model_name_or_path: str, **kwargs)`
 
@@ -139,11 +148,11 @@ Now we can see below that you get a list of Flair sentences tagged with the "ner
 ```python
 print("List entities tagged:\n")print("List entities tagged:\n")
 for sen in sentences:
-    for entity in sen.get_spans("pos"):
+    for entity in sen.get_spans(tag_type="pos"):
         print(entity)
         
 for sen in sentences:
-    for entity in sen.get_spans("ner"):
+    for entity in sen.get_spans(tag_type="ner"):
         print(entity)
 ```
 


### PR DESCRIPTION
Fix some autodoc issues with kwargs param in `EasySequenceClassifier`

Show `tag_type` params for Flair `Sentence` objects.

Show accessible `tag_type` variables in the documentation.