### PR TITLE
split development tools into requirements_dev.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ Install using pip in your virtual environment:
 pip install adaptnlp
 ```
 
+If you want to work on AdaptNLP, `pip install adaptnlp[dev]` will install its development tools.
+
 
 #### Examples and General Use
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,4 @@
 click
-flake8
-black
 jupyter
 jupyterlab
 transformers==2.8.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,0 +1,2 @@
+flake8
+black

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,9 @@ version = version_file.read_text(encoding="UTF-8").strip()
 with open("requirements.txt") as reqs_file:
     install_requires = reqs_file.read().splitlines()
 
+with open("requirements_dev.txt") as reqs_dev_file:
+    dev_requires = reqs_dev_file.read().splitlines()
+
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
@@ -28,6 +31,9 @@ setup(
         "NER",
     ],
     install_requires=install_requires,
+    extras_require={
+        'dev': dev_requires
+    },
     license="Apache 2.0",
     description="AdaptNLP: A Natural Language Processing Library and Framework",
     long_description=long_description,


### PR DESCRIPTION
This will hold off on installing black and flake8 unless the user runs `pip install adaptnlp[dev]`.

Technique found here: https://stackoverflow.com/a/28842733/1286978