### PR TITLE
Raise python requirements to python 3.7+ for latest AdaptNLP release …

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   cache_and_run_tests:
     docker:
-      - image: circleci/python:3.6
+      - image: circleci/python:3.7
     resource_class: xlarge
     working_directory: ~/adaptnlp
     steps:
@@ -30,7 +30,7 @@ jobs:
             python3 -m pytest
   deploy_doc:
     docker:
-      - image: circleci/python:3.6
+      - image: circleci/python:3.7
     working_directory: ~/adaptnlp
     steps:
       - checkout

--- a/README.md
+++ b/README.md
@@ -53,9 +53,11 @@ Learning Researchers and Scientists a modular and **adaptive** approach to a var
 
 #### Requirements and Installation for Linux/Mac
 
+Note: AdaptNLP will be using the latest stable torch version (v1.7 as of 11/2/20) which requires Python 3.7+. Please downgrade torch<=1.6 if using Python 3.6
+
 ##### Virtual Environment
 To avoid dependency clustering and issues, it would be wise to install AdaptNLP in a virtual environment.
-To create a new python 3.6+ virtual environment, run this command and then activate it however your operating
+To create a new python 3.7+ virtual environment, run this command and then activate it however your operating
 system specifies:
 
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -53,9 +53,11 @@ Learning Researchers and Scientists a modular and **adaptive** approach to a var
 
 #### Requirements and Installation for Linux/Mac
 
+Note: AdaptNLP will be using the latest stable torch version (v1.7 as of 11/2/20) which requires Python 3.7+. Please downgrade torch<=1.6 if using Python 3.6
+
 ##### Virtual Environment
 To avoid dependency clustering and issues, it would be wise to install AdaptNLP in a virtual environment.
-To create a new python 3.6+ virtual environment, run this command and then activate it however your operating
+To create a new python 3.7+ virtual environment, run this command and then activate it however your operating
 system specifies:
 
 ```


### PR DESCRIPTION
…to close #96. Builds for CI will use python 3.7