### PR TITLE
Cuda container with Flair and Python 3.8 mmap compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,11 +243,11 @@ Images can build with GPU support if NVIDA-Docker is correctly installed.
 #### Pull and Run AdaptNLP Immediately
 Simply run an image with AdaptNLP installed from source in developer mode by running:
 ```
-docker run -itp 8888:8888 achangnovetta/adaptnlp:latest bash
+docker run -itp 8888:8888 achangnovetta/adaptnlp:latest
 ```
 Run an image with AdaptNLP running on GPUs if you have nvidia drivers and nvidia-docker 19.03+ installed:
 ```
-docker run -itp 8888:8888 --gpus all achangnovetta/adaptnlp:latest bash
+docker run -itp 8888:8888 --gpus all achangnovetta/adaptnlp:latest
 ```
 
 Check `localhost:8888` or `localhost:8888/lab` to access the container notebook servers.
@@ -261,7 +261,7 @@ Note: A container with GPUs enabled requires Docker version 19.03+ and nvida-doc
 ```
 # From the repo directory
 docker build -t achangnovetta/adaptnlp:latest -f docker/runtime/Dockerfile.cuda11.0-runtime-ubuntu18.04-py3.8 .
-docker run -itp 8888:8888 achangnovetta/adaptnlp:latest bash
+docker run -itp 8888:8888 achangnovetta/adaptnlp:latest
 ```
 If you want to use CUDA compatible GPUs 
 ```

--- a/docker/devel/Dockerfile.cuda10.2-devel-ubuntu18.04-py3.8
+++ b/docker/devel/Dockerfile.cuda10.2-devel-ubuntu18.04-py3.8
@@ -14,7 +14,11 @@ ENV PYTHONUNBUFFERED=1 \
     PIP_DEFAULT_TIMEOUT=100
 
 # Install python
-RUN apt-get update && apt-get install -y --no-install-recommends \
+# Add deadsnakes ppa for python version >= 3.8.2
+RUN apt-get update && \
+    apt-get install -y software-properties-common
+RUN add-apt-repository ppa:deadsnakes/ppa
+RUN apt-get install -y --no-install-recommends \
     build-essential \
     python3.8 \
     python3.8-dev \

--- a/docker/devel/Dockerfile.cuda11.0-devel-ubuntu18.04-py3.8
+++ b/docker/devel/Dockerfile.cuda11.0-devel-ubuntu18.04-py3.8
@@ -14,7 +14,11 @@ ENV PYTHONUNBUFFERED=1 \
     PIP_DEFAULT_TIMEOUT=100
 
 # Install python
-RUN apt-get update && apt-get install -y --no-install-recommends \
+# Add deadsnakes ppa for python version >= 3.8.2
+RUN apt-get update && \
+    apt-get install -y software-properties-common
+RUN add-apt-repository ppa:deadsnakes/ppa
+RUN apt-get install -y --no-install-recommends \
     build-essential \
     python3.8 \
     python3.8-dev \

--- a/docker/runtime/Dockerfile.cuda10.2-runtime-ubuntu18.04-py3.8
+++ b/docker/runtime/Dockerfile.cuda10.2-runtime-ubuntu18.04-py3.8
@@ -14,7 +14,11 @@ ENV PYTHONUNBUFFERED=1 \
     PIP_DEFAULT_TIMEOUT=100
 
 # Install python
-RUN apt-get update && apt-get install -y --no-install-recommends \
+# Add deadsnakes ppa for python version >= 3.8.2
+RUN apt-get update && \
+    apt-get install -y software-properties-common
+RUN add-apt-repository ppa:deadsnakes/ppa
+RUN apt-get install -y --no-install-recommends \
     build-essential \
     python3.8 \
     python3.8-dev \

--- a/docker/runtime/Dockerfile.cuda11.0-runtime-ubuntu18.04-py3.8
+++ b/docker/runtime/Dockerfile.cuda11.0-runtime-ubuntu18.04-py3.8
@@ -14,7 +14,11 @@ ENV PYTHONUNBUFFERED=1 \
     PIP_DEFAULT_TIMEOUT=100
 
 # Install python
-RUN apt-get update && apt-get install -y --no-install-recommends \
+# Add deadsnakes ppa for python version >= 3.8.2
+RUN apt-get update && \
+    apt-get install -y software-properties-common
+RUN add-apt-repository ppa:deadsnakes/ppa
+RUN apt-get install -y --no-install-recommends \
     build-essential \
     python3.8 \
     python3.8-dev \

--- a/docs/index.md
+++ b/docs/index.md
@@ -286,11 +286,11 @@ Images can build with GPU support if NVIDA-Docker is correctly installed.
 #### Pull and Run AdaptNLP Immediately
 Simply run an image with AdaptNLP installed from source in developer mode by running:
 ```
-docker run -itp 8888:8888 achangnovetta/adaptnlp:latest bash
+docker run -itp 8888:8888 achangnovetta/adaptnlp:latest
 ```
 Run an image with AdaptNLP running on GPUs if you have nvidia drivers and nvidia-docker 19.03+ installed:
 ```
-docker run -itp 8888:8888 --gpus all achangnovetta/adaptnlp:latest bash
+docker run -itp 8888:8888 --gpus all achangnovetta/adaptnlp:latest
 ```
 
 Check `localhost:8888` or `localhost:8888/lab` to access the container notebook servers.
@@ -304,7 +304,7 @@ Note: A container with GPUs enabled requires Docker version 19.03+ and nvida-doc
 ```
 # From the repo directory
 docker build -t achangnovetta/adaptnlp:latest -f docker/runtime/Dockerfile.cuda11.0-runtime-ubuntu18.04-py3.8 .
-docker run -itp 8888:8888 achangnovetta/adaptnlp:latest bash
+docker run -itp 8888:8888 achangnovetta/adaptnlp:latest
 ```
 If you want to use CUDA compatible GPUs 
 ```


### PR DESCRIPTION
Use ppa deadsnakes in docker image for python 3.8 so we can have verion>=3.8.2

Address readme docker directions for easier quick start.

